### PR TITLE
Aliased Pastee.paste() to Pastee.submit() for prototype consistency with examples

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,4 +98,6 @@ Pastee.prototype.getTimeSeconds = function(date) {
 	return date.getTime() / 1000;
 };
 
+Pastee.prototype.submit = Pastee.prototype.paste
+
 module.exports = Pastee;


### PR DESCRIPTION
Since the examples all have paste.submit() instead of paste.paste() as is in the Pastee prototype, added an alias Pastee.submit() for Pastee.paste() in the prototype.

Alternate pull request submitted for the more complex, and probably less correct, fix of replacing all instances of paste.submit() with paste.paste() in the examples.
