### PR TITLE
Replace each instance of paste.submit with paste.paste for example consistency with actual prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var Pastee = require('pastee');
 var paste = new Pastee('api key or not set for public');
 
 // Submit a normal paste
-paste.submit('paste contents', function(err, res) {
+paste.paste('paste contents', function(err, res) {
 	// res is a json object with "id", "link", "raw", "download" (and "key" for encrypted)
 });
 
@@ -38,7 +38,7 @@ paste.retrieve('paste id', function(err, res) {
 
 ## Extra options
 
-The following fields can be passed into an object for the first argument of paste.submit
+The following fields can be passed into an object for the first argument of paste.paste
 
 * paste
 * description

--- a/example.js
+++ b/example.js
@@ -3,7 +3,7 @@ var Pastee = require('pastee');
 var paste = new Pastee(); // Add a single string param to set the api key
 
 // Submit a normal paste
-paste.submit('paste contents', function(err, res) {
+paste.paste('paste contents', function(err, res) {
 	// res is a json object with "id", "link", "raw", "download" (and "key" for encrypted)
 });
 
@@ -17,8 +17,8 @@ paste.retrieve('paste id', function(err, res) {
 });
 
 // Submit an encrypted paste
-var key = paste.submit({ paste : 'paste contents', encrypt : true }, function(err, res) {
-	// res is the same as above, but with "key", and "link" has the key appended to it (submit also returns key)
+var key = paste.paste({ paste : 'paste contents', encrypt : true }, function(err, res) {
+	// res is the same as above, but with "key", and "link" has the key appended to it (paste also returns key)
 });
 
 // Retrieve an encrypted paste


### PR DESCRIPTION
Since the examples all have paste.submit() instead of paste.paste() as is in the Pastee prototype, replaced all instances of paste.submit() with paste.paste().

Alternate pull request submitted for the simpler, and probably more correct, fix of aliasing Pastee.paste() to Pastee.submit() in the prototype.
